### PR TITLE
修复messenger跨域下无权限访问的bug

### DIFF
--- a/src/messenger.js
+++ b/src/messenger.js
@@ -4,12 +4,12 @@ define(function(require, exports, module) {
 
     function Messenger(config) {
         var win = config.target || parent;
-        win = $(win);
-        if (win[0] && win[0].tagName === 'IFRAME') {
-            win = win[0].contentWindow;
-        }
-        else {
-            win = win[0];
+        
+        if( typeof win == 'string' ){
+            win = $(win).get(0);
+        	if (win && win.tagName === 'IFRAME') {
+                win = win.contentWindow;
+        	}
         }
 
         // save the pointer to the window which is interacting with        

--- a/src/messenger.js
+++ b/src/messenger.js
@@ -7,9 +7,9 @@ define(function(require, exports, module) {
         
         if( typeof win == 'string' ){
             win = $(win).get(0);
-    	if (win && win.tagName === 'IFRAME') {
-            win = win.contentWindow;
-    	}
+            if (win && win.tagName === 'IFRAME') {
+                win = win.contentWindow;
+            }
         }
 
         // save the pointer to the window which is interacting with        

--- a/src/messenger.js
+++ b/src/messenger.js
@@ -7,9 +7,9 @@ define(function(require, exports, module) {
         
         if( typeof win == 'string' ){
             win = $(win).get(0);
-        	if (win && win.tagName === 'IFRAME') {
-                win = win.contentWindow;
-        	}
+    	if (win && win.tagName === 'IFRAME') {
+            win = win.contentWindow;
+    	}
         }
 
         // save the pointer to the window which is interacting with        


### PR DESCRIPTION
Messenger构造函数中，使用了$(win)及win.tagName,  $(win)函数中用到了，win.nodeType属性， 而这两个属性(nodeType，tagName)在跨域情况下，当win为parent对象时是都不允许被访问的，代码改为 
if( typeof win == 'string' ){
            win = $(win).get(0);
            if (win && win.tagName === 'IFRAME') {
            win = win.contentWindow;
            }
        }
