### PR TITLE
fix ie6 7 cross domain issue

### DIFF
--- a/src/messenger.js
+++ b/src/messenger.js
@@ -158,7 +158,7 @@ define(function(require, exports, module) {
             } catch (ex) {}
 
             // if the name property can not be accessed, try to change the messenger iframe's location to 'about blank'
-            this.receiverWin.location.replace('javascript:"";');
+            this.receiverWin.location.replace('about:blank');
             // We have to delay receiving to avoid access-denied error.
             var self = this;
             setTimeout(function () {


### PR DESCRIPTION
由于文档中的例子是在同一个域上的通讯，所以是没有问题的。做了一个跨域访问的例子，在IE7上面会报错：

![IE7 error](https://raw.github.com/dafeizizhu/Resources/master/images/2013-11-01-IE7-error.PNG)

在IE6上则什么反应都没有，也不报错。

参考了原来[MessagerJS](https://github.com/biqing/MessengerJS)的代码之后，发现其中一个地方的`about:blank`被改成了`javascript:"";`，把它改回去就好了，在IE6、IE7、Chrome、FireFox上验证通过。
